### PR TITLE
refactor(interceptors): 重命名拦截器并优化类型导出

### DIFF
--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,9 +1,9 @@
 import type { RouteInterceptorOptions } from "uni-toolkit";
 import {
-  KuaiShouSetStorageProxyFixInterceptor,
   makePhoneCallInterceptor,
   RouteInterceptor,
-  SetClipboardDataAuthInterceptor,
+  SetClipboardDataInterceptor,
+  StorageInterceptor,
 } from "uni-toolkit";
 import { createSSRApp } from "vue";
 import { isLogged, loginRoute, needLoginPages } from "@/interceptor/route";
@@ -16,10 +16,10 @@ export function createApp(): any {
   app.use<RouteInterceptorOptions>(RouteInterceptor, { loginRoute, isLogged, needLoginPages });
   app.use(makePhoneCallInterceptor);
   // #ifdef MP-KUAISHOU
-  app.use(KuaiShouSetStorageProxyFixInterceptor);
+  app.use(StorageInterceptor);
   // #endif
   // #ifdef MP-TOUTIAO
-  app.use(SetClipboardDataAuthInterceptor);
+  app.use(SetClipboardDataInterceptor);
   // #endif
   return {
     app,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,15 @@ export {
 
 export {
   applyChooseLocationInterceptor,
-  applyKuaiShouSetStorageProxyFixInterceptor,
   applyMakePhoneCallInterceptor,
   applyRouteInterceptor,
-  applySetClipboardDataAuthInterceptor,
+  applySetClipboardDataInterceptor,
+  applyStorageInterceptor,
   chooseLocationInterceptor,
-  KuaiShouSetStorageProxyFixInterceptor,
   makePhoneCallInterceptor,
   RouteInterceptor,
-  SetClipboardDataAuthInterceptor,
+  SetClipboardDataInterceptor,
+  StorageInterceptor,
 } from "./interceptors";
 
 export { type RouteInterceptorOptions } from "./interceptors";
@@ -24,3 +24,5 @@ export { type RouteInterceptorOptions } from "./interceptors";
 export {
   cloneDeep,
 } from "./tools";
+
+export type { MiniProgramPlatform } from "./typings";

--- a/src/interceptors/index.ts
+++ b/src/interceptors/index.ts
@@ -2,5 +2,5 @@ export { applyChooseImageInterceptor, chooseImageInterceptor } from "./chooseIma
 export { applyChooseLocationInterceptor, chooseLocationInterceptor } from "./chooseLocation";
 export { applyMakePhoneCallInterceptor, makePhoneCallInterceptor } from "./makePhoneCall";
 export { applyRouteInterceptor, checkLoginAndRedirect, RouteInterceptor, type RouteInterceptorOptions } from "./route";
-export { applySetClipboardDataAuthInterceptor, SetClipboardDataAuthInterceptor } from "./setClipboardData";
-export { applyKuaiShouSetStorageProxyFixInterceptor, KuaiShouSetStorageProxyFixInterceptor } from "./setStorage";
+export { applySetClipboardDataInterceptor, SetClipboardDataInterceptor } from "./setClipboardData";
+export { applyStorageInterceptor, StorageInterceptor } from "./setStorage";

--- a/src/interceptors/setClipboardData.ts
+++ b/src/interceptors/setClipboardData.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "vue";
 
-const clipboardDataAuthInterceptor: UniNamespace.InterceptorOptions = {
+const clipboardDataInterceptor: UniNamespace.InterceptorOptions = {
   fail(error: any) {
     // #ifdef MP-TOUTIAO
     // 抖音小程序用户拒绝授权剪贴板权限
@@ -36,17 +36,17 @@ const clipboardDataAuthInterceptor: UniNamespace.InterceptorOptions = {
  * 处理抖音小程序剪贴板授权拦截器
  * 当用户拒绝授权时，引导用户去设置页面授权
  */
-export const SetClipboardDataAuthInterceptor: Plugin = {
+export const SetClipboardDataInterceptor: Plugin = {
   install() {
-    uni.addInterceptor("setClipboardData", clipboardDataAuthInterceptor);
+    uni.addInterceptor("setClipboardData", clipboardDataInterceptor);
   },
 };
 
 /**
- * 直接应用剪贴板数据授权拦截器
- * 可以作为 Vue 插件使用: Vue.use(SetClipboardDataAuthInterceptor)
- * 也可以直接调用: applySetClipboardDataAuthInterceptor()
+ * 直接应用剪贴板数据拦截器
+ * 可以作为 Vue 插件使用: Vue.use(SetClipboardDataInterceptor)
+ * 也可以直接调用: applySetClipboardDataInterceptor()
  */
-export function applySetClipboardDataAuthInterceptor(): void {
-  SetClipboardDataAuthInterceptor.install?.(null as any);
+export function applySetClipboardDataInterceptor(): void {
+  SetClipboardDataInterceptor.install?.(null as any);
 }

--- a/src/interceptors/setStorage.ts
+++ b/src/interceptors/setStorage.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "vue";
 
-const storageInvokeInterceptor: UniNamespace.InterceptorOptions = {
+const storageInterceptor: UniNamespace.InterceptorOptions = {
   invoke(args: { data: any }) {
     // #ifdef MP-KUAISHOU
     args.data = JSON.parse(JSON.stringify(args.data));
@@ -19,17 +19,17 @@ const storageInvokeInterceptor: UniNamespace.InterceptorOptions = {
  * 解决快手小程序setStorage不支持proxy对象的问题
  * - 相关链接: https://github.com/dcloudio/uni-app/issues/4182
  */
-export const KuaiShouSetStorageProxyFixInterceptor: Plugin = {
+export const StorageInterceptor: Plugin = {
   install() {
-    uni.addInterceptor("setStorage", storageInvokeInterceptor);
+    uni.addInterceptor("setStorage", storageInterceptor);
   },
 };
 
 /**
  * 直接应用快手小程序setStorage代理修复拦截器
- * 可以作为 Vue 插件使用: Vue.use(KuaiShouSetStorageProxyFixInterceptor)
- * 也可以直接调用: applyKuaiShouSetStorageProxyFixInterceptor()
+ * 可以作为 Vue 插件使用: Vue.use(StorageInterceptor)
+ * 也可以直接调用: applyStorageInterceptor()
  */
-export function applyKuaiShouSetStorageProxyFixInterceptor(): void {
-  KuaiShouSetStorageProxyFixInterceptor.install?.(null as any);
+export function applyStorageInterceptor(): void {
+  StorageInterceptor.install?.(null as any);
 }

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,20 +1,20 @@
 /// <reference types="@dcloudio/types" />
 
+/**
+ * 小程序平台类型
+ */
+export type MiniProgramPlatform
+  = | "mp-alipay"
+    | "mp-weixin"
+    | "mp-baidu"
+    | "mp-qq"
+    | "mp-toutiao"
+    | "mp-kuaishou"
+    | "mp-jd"
+    | "app"
+    | "h5";
 /* eslint-disable ts/consistent-type-definitions */
 declare global {
-  /**
-   * 小程序平台类型
-   */
-  type MiniProgramPlatform
-    = | "mp-alipay"
-      | "mp-weixin"
-      | "mp-baidu"
-      | "mp-qq"
-      | "mp-toutiao"
-      | "mp-kuaishou"
-      | "mp-jd"
-      | "app"
-      | "h5";
 
   namespace NodeJS {
     interface ProcessEnv {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { KuaiShouSetStorageProxyFixInterceptor, SetClipboardDataAuthInterceptor } from "../src/interceptors";
+import { SetClipboardDataInterceptor, StorageInterceptor } from "../src/interceptors";
 
 describe("interceptors", () => {
-  it("should export SetClipboardDataAuthInterceptor", () => {
-    expect(SetClipboardDataAuthInterceptor).toBeDefined();
-    expect(SetClipboardDataAuthInterceptor.install).toBeTypeOf("function");
+  it("should export SetClipboardDataInterceptor", () => {
+    expect(SetClipboardDataInterceptor).toBeDefined();
+    expect(SetClipboardDataInterceptor.install).toBeTypeOf("function");
   });
 
-  it("should export KuaiShouSetStorageProxyFixInterceptor", () => {
-    expect(KuaiShouSetStorageProxyFixInterceptor).toBeDefined();
-    expect(KuaiShouSetStorageProxyFixInterceptor.install).toBeTypeOf("function");
+  it("should export StorageInterceptor", () => {
+    expect(StorageInterceptor).toBeDefined();
+    expect(StorageInterceptor.install).toBeTypeOf("function");
   });
 });


### PR DESCRIPTION
将 SetClipboardDataAuthInterceptor 重命名为 SetClipboardDataInterceptor 将 KuaiShouSetStorageProxyFixInterceptor 重命名为 StorageInterceptor 将 MiniProgramPlatform 类型从全局声明移至模块导出

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增公开类型 MiniProgramPlatform，便于类型标注与平台判断。
- 重构
  - 统一拦截器命名：SetClipboardDataAuthInterceptor 更名为 SetClipboardDataInterceptor；KuaiShouSetStorageProxyFixInterceptor 更名为 StorageInterceptor。
  - 相应 apply* 方法同步更名，并在平台条件注入中采用新名称；运行时行为不变。
- 测试
  - 更新测试用例以匹配新的公开 API 命名，验证安装流程与导出完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->